### PR TITLE
FortiWeb AWR: renewal-safe rotation (unique-name upload, policy/SNI/multi-cert repoint, algorithm scoping)

### DIFF
--- a/TrustLifeCycleManager/Integrations/Fortinet/FortiWEB/fortiweb-awr.sh
+++ b/TrustLifeCycleManager/Integrations/Fortinet/FortiWEB/fortiweb-awr.sh
@@ -321,7 +321,7 @@ except Exception:
     sys.exit(0)
 res = d.get("results", []) if isinstance(d, dict) else d
 for c in (res if isinstance(res, list) else [res]):
-    if isinstance(c, dict) and (c.get("name") or c.get("_id")) == name:
+    if isinstance(c, dict) and name in (c.get("name"), c.get("_id"), c.get("mkey")):
         pt = c.get("pkey_type")
         if pt is not None:
             print(pt)
@@ -351,7 +351,7 @@ res = d.get("results", []) if isinstance(d, dict) else d
 for c in (res if isinstance(res, list) else [res]):
     if not isinstance(c, dict):
         continue
-    name = c.get("name") or c.get("_id")
+    name = c.get("name") or c.get("_id") or c.get("mkey")
     m = re.search(r"CN\s*=\s*([^,/]+)", c.get("subject") or "")
     cn = m.group(1).strip().lower() if m else ""
     if not name or name == exclude or not cn or cn != target:
@@ -668,7 +668,7 @@ except Exception:
     print("unknown"); sys.exit(0)
 res = d.get("results", []) if isinstance(d, dict) else d
 for c in (res if isinstance(res, list) else [res]):
-    if isinstance(c, dict) and c.get("name") == target:
+    if isinstance(c, dict) and target in (c.get("name"), c.get("_id"), c.get("mkey")):
         print("yes" if c.get("can_delete") else "no"); sys.exit(0)
 print("absent")
 ' "$OLD_CERT" 2>/dev/null)

--- a/TrustLifeCycleManager/Integrations/Fortinet/FortiWEB/fortiweb-awr.sh
+++ b/TrustLifeCycleManager/Integrations/Fortinet/FortiWEB/fortiweb-awr.sh
@@ -413,8 +413,8 @@ for c in (res if isinstance(res, list) else [res]):
                 --show-error \
                 2>&1)
 
-# Remove the staged private key material
-rm -rf "$STAGE_DIR"
+            # Securely remove the staged private key material
+            rm -rf "$STAGE_DIR"
 
             # Extract HTTP status code and response body
             HTTP_STATUS=$(echo "$CURL_RESPONSE" | grep "HTTP_STATUS:" | cut -d':' -f2)


### PR DESCRIPTION
## Summary

Follow-up commits on the FortiWeb AWR script (the core renewal-safe rotation feature is already on `master`). This PR contains:

- **Consistency hardening** — cert-list lookups (`get_cert_pkey_type`, `get_cert_names_by_cn`, and the `can_delete` safety gate) now match on `name`, `_id`, **and** `mkey`, so an off-version API response that keys on `mkey` still selects and rotates certs correctly. Low-risk future-proofing; validated on 8.0.5 where the list returns `name`/`_id`.
- **Cleanup** — restored the original indentation and "Securely remove the staged private key material" comment on the staged-key `rm -rf` (a Copilot Autofix had de-indented it to column 0; functionally harmless in bash, cosmetically inconsistent).

## Context

The full rotation behavior this builds on (unique-name upload to avoid FortiWeb's duplicate-name limitation, subject-CN + key-algorithm scoping so RSA/ECC certs of the same CN don't clobber each other, repointing of server-policy / SNI-member / multi-cert-group references, `can_delete` safety gate, and auth-token log redaction) was validated end-to-end against FortiWeb 8.0.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)