### PR TITLE
Included changes:

### DIFF
--- a/TrustLifeCycleManager/Integrations/MS_IIS_Multiple_Sites_and_ports/README.md
+++ b/TrustLifeCycleManager/Integrations/MS_IIS_Multiple_Sites_and_ports/README.md
@@ -72,6 +72,8 @@ If this is not `"true"`, the script logs the reason and exits `1`.
 |---|---|---|
 | `$IIS_TARGET_SITES` | 4 sites | Sites whose https bindings are re-pointed. Used when discovery mode is `List` |
 | `$IIS_SITE_DISCOVERY_MODE` | `'List'` | `'List'` = only the sites above. `'AllHttps'` = every IIS site with at least one https binding |
+| `$IIS_PFX_VARIANT` | `'Legacy'` | `'Legacy'` / `'Modern'` / `'First'` — which delivered PFX to deploy when the payload contains more than one. See [Modern or Legacy PFX](#modern-or-legacy-pfx) |
+| `$IIS_PFX_FILE_PATTERN` | `''` | Advanced. Raw regex overriding `$IIS_PFX_VARIANT`; only needed if the file names do not follow the `_legacy` convention |
 | `$IIS_EXPECTED_SUBJECT_CN` | `'iis-01.digicert-demo.com'` | Safety net — abort before touching anything if the new certificate does not carry this CN. Set to `''` to disable |
 | `$IIS_CERT_STORE_NAME` | `'My'` | Store under `LocalMachine` that receives the leaf certificate |
 | `$IIS_IMPORT_CHAIN` | `$true` | Install intermediates found in the PFX into `LocalMachine\CA` |
@@ -90,10 +92,97 @@ Three settings can be overridden per job from the AWR profile, without editing t
 | **Parameter 1** | Comma-separated site list (e.g. `ws1-digicert-demo,ws2-digicert-demo`), or `ALL` / `*` to switch to `AllHttps` discovery |
 | **Parameter 2** | Expected subject CN, or `NONE` to disable the CN safety check |
 | **Parameter 3** | `REMOVEOLD` to delete the certificate that was replaced |
+| **Parameter 4** | `LEGACY`, `MODERN` or `FIRST` — which delivered PFX to deploy. Overrides `$IIS_PFX_VARIANT`. Any other value is ignored with a warning |
 
 Arguments are whitespace-stripped during extraction, so **site names containing spaces** (e.g. `Default Web Site`) cannot be passed this way — leave those in `$IIS_TARGET_SITES`.
 
 > **Why this block is not at the top of the file with everything else:** it reads `$ARGUMENT_1` … `$ARGUMENT_3`, which do not exist until `DC1_POST_SCRIPT_DATA` has been Base64-decoded and parsed. Hoisted to the top, the overrides would silently never fire. The block therefore stays immediately after argument extraction, with a pointer comment back to the configuration block.
+>
+> Parameter 4 is applied **earlier still** — at PFX selection time — because `$PFX_FILE` has to be resolved before that block is reached.
+
+### Modern or Legacy PFX
+
+TLM can deliver **two PFX files for the same certificate** in one payload:
+
+```
+iis-01.digicert-demo.com.pfx           <- Modern
+iis-01.digicert-demo.com_legacy.pfx    <- Legacy
+```
+
+Set `$IIS_PFX_VARIANT` to pick one — no regex required:
+
+| Value | Selects | Use when |
+|---|---|---|
+| `'Legacy'` | the `*_legacy` file **(current default)** | The target host cannot read the modern container — Windows Server 2016 and older are the usual cases |
+| `'Modern'` | the plain file | Everything on the target host can read AES-256 PKCS#12 |
+| `'First'` | whatever the payload lists first | Only sensible when a single PFX is delivered |
+
+`'First'` is supported but **not recommended when two files are delivered**: the choice then follows the payload's array order, which is not guaranteed to be stable between renewals. The script logs a warning in exactly that situation.
+
+#### What actually differs between them
+
+The certificate, the private key and the chain are the **same**. Only the PKCS#12 container differs — the algorithms used to encrypt the file and to MAC it:
+
+```
+========== Modern ==========
+MAC: sha256, Iteration 2048
+PKCS7 Encrypted data: PBES2, PBKDF2, AES-256-CBC, Iteration 2048, PRF hmacWithSHA256
+Shrouded Keybag:      PBES2, PBKDF2, AES-256-CBC, Iteration 2048, PRF hmacWithSHA256
+
+========== Legacy ==========
+MAC: sha1, Iteration 2048
+PKCS7 Encrypted data: pbeWithSHA1And40BitRC2-CBC, Iteration 2048
+Shrouded Keybag:      pbeWithSHA1And3-KeyTripleDES-CBC, Iteration 2048
+```
+
+The **MAC** is a keyed integrity tag over the whole file, with its key derived from the same password that encrypts the contents. Implementations verify it before decrypting anything, so *any* container problem — wrong password, unsupported encryption, unsupported MAC hash — surfaces as the same complaint: **"the specified network password is not correct."** A host that needs the legacy file therefore looks exactly like a wrong-password problem.
+
+Encryption and MAC are **independent** compatibility hurdles, set by separate flags, so a file can be modern on one axis and legacy on the other. Read both lines when inspecting.
+
+The weak legacy algorithms (RC2-40, 3DES, SHA-1) protect the **file in transit only**. Whichever variant you choose, the certificate and private key bound to IIS are byte-for-byte identical — TLS strength is unaffected.
+
+#### Verifying your own files
+
+Container algorithms, which settles the Modern/Legacy question:
+
+```
+openssl pkcs12 -info -in <file>.pfx        -passin pass:<password> -noout
+openssl pkcs12 -info -in <file>_legacy.pfx -passin pass:<password> -noout -legacy
+```
+
+Contents, to confirm the leaf and chain really are identical:
+
+```powershell
+$pw = '<the PFX password>'
+foreach ($f in Get-ChildItem -Path . -Filter *.pfx | Sort-Object Name) {
+    $col = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2Collection
+    $col.Import($f.FullName, $pw, 'DefaultKeySet')
+    ''
+    "=== $($f.Name)  ($($col.Count) certificate(s)) ==="
+    foreach ($c in $col) {
+        $role = if ($c.HasPrivateKey) { 'LEAF ' } elseif ($c.Subject -eq $c.Issuer) { 'root ' } else { 'inter' }
+        '  {0} {1}  {2}' -f $role, $c.Thumbprint, $c.Subject
+        '        issued by {0}' -f $c.Issuer
+    }
+}
+```
+
+Compare the **LEAF thumbprints**:
+
+- **Identical** — container encryption is the only difference, as described above. Switching variants changes nothing about what gets bound; it only changes whether the host can open the file
+- **Different** — these are genuinely different certificates, not just different containers, and switching changes the certificate the bindings point at
+
+#### The selection is always logged
+
+```
+[…] PFX candidates in payload (2): iis-01.digicert-demo.com.pfx, iis-01.digicert-demo.com_legacy.pfx
+[…] Selected the PFX for variant Legacy (older PKCS#12 container): iis-01.digicert-demo.com_legacy.pfx
+```
+
+If nothing matches the chosen variant, the script warns and falls back to the first PFX rather than failing — asking for Legacy and silently getting Modern is the mix-up this setting exists to prevent, so that warning is worth watching for.
+
+> **Advanced:** `$IIS_PFX_FILE_PATTERN` remains available as a raw regex override and wins over `$IIS_PFX_VARIANT` when non-empty. Leave it `''` unless the delivered file names do not follow the `_legacy` convention above.
+
 
 ### Log File
 
@@ -371,6 +460,11 @@ Useful when the sites are stopped or firewalled and the `TLS SKIPPED` lines are 
 | `HTTP.SYS OK` but `TLS FAIL` | Something else is answering on that IP and port, or the site is bound to a different certificate at another layer |
 | `TLS SKIPPED` on every binding | Sites stopped, or a firewall is blocking the loopback probe. Not an error — the config and `http.sys` checks are authoritative. Set `$IIS_VERIFY_TLS_HANDSHAKE = $false` to silence |
 | `ERROR: IIS site '…' does not exist` | Site name mismatch. Matching is case-insensitive but otherwise exact — no trimming beyond the whitespace stripping applied to AWR arguments, which is also why names containing spaces cannot be passed via AWR Parameter 1 |
+| `ERROR: Unable to read the PFX (wrong password or corrupt file?)` | Check the password first — but on Windows Server 2016 and older this is also what an unreadable **modern PKCS#12 container** looks like. If the password is definitely right, set `$IIS_PFX_VARIANT = 'Legacy'`. See [Modern or Legacy PFX](#modern-or-legacy-pfx) |
+| `WARNING: no delivered PFX matched …` | The chosen variant matched none of the delivered files, so the **first** PFX was deployed instead — possibly the wrong container. Check the logged candidate list against `$IIS_PFX_VARIANT` |
+| `WARNING: N PFX files were delivered and no variant filter applies` | Two or more PFX files in the payload with `$IIS_PFX_VARIANT = 'First'` (or an unrecognised value), so payload order decided. Set `Legacy` or `Modern` |
+| `WARNING: AWR Parameter 4 '…' is not LEGACY, MODERN or FIRST` | Parameter 4 was set to something else and ignored; the configured `$IIS_PFX_VARIANT` was used instead |
+| Wrong file deployed after a successful run | Read the `Selected the PFX for variant …` log line, then verify the file's contents with the commands in [Modern or Legacy PFX](#modern-or-legacy-pfx) |
 | Bindings revert after a later IIS change | Indicates only `http.sys` was updated, not `applicationHost.config`. Both are written here — check the log for a commit failure |
 
 ## License

--- a/TrustLifeCycleManager/Integrations/MS_IIS_Multiple_Sites_and_ports/ms_iis_multiple-awr.ps1
+++ b/TrustLifeCycleManager/Integrations/MS_IIS_Multiple_Sites_and_ports/ms_iis_multiple-awr.ps1
@@ -92,6 +92,51 @@ $IIS_TARGET_SITES = @(
 # 'AllHttps' - every IIS site that has at least one https binding
 $IIS_SITE_DISCOVERY_MODE = 'List'
 
+# ---- Which delivered PFX to deploy -----------------------------------------
+#
+# TLM can deliver two PFX files for the same certificate:
+#
+#     iis-01.digicert-demo.com.pfx           <- 'Modern'
+#     iis-01.digicert-demo.com_legacy.pfx    <- 'Legacy'
+#
+# The certificate, the private key and the chain inside them are the SAME. Only
+# the PKCS#12 container differs - the algorithms used to encrypt the file and to
+# MAC it (the MAC is a keyed integrity tag over the file, derived from the same
+# password, which is why a container problem gets reported as a bad password):
+#
+#     ========== Modern ==========
+#     MAC: sha256, Iteration 2048
+#     PKCS7 Encrypted data: PBES2, PBKDF2, AES-256-CBC, Iteration 2048, PRF hmacWithSHA256
+#     Shrouded Keybag:      PBES2, PBKDF2, AES-256-CBC, Iteration 2048, PRF hmacWithSHA256
+#
+#     ========== Legacy ==========
+#     MAC: sha1, Iteration 2048
+#     PKCS7 Encrypted data: pbeWithSHA1And40BitRC2-CBC, Iteration 2048
+#     Shrouded Keybag:      pbeWithSHA1And3-KeyTripleDES-CBC, Iteration 2048
+#
+# Older Windows CryptoAPI cannot read the modern container, and it reports that
+# as "the specified network password is not correct" - so a host that needs the
+# legacy file looks exactly like a wrong-password problem. Windows Server 2016
+# and older are the usual cases; verify on the target host rather than assuming.
+#
+# The weak legacy algorithms (RC2-40, 3DES, SHA-1) protect the file in transit
+# only. Whichever variant is chosen, the certificate and private key that end up
+# bound to IIS are byte-for-byte identical, so TLS strength is unaffected.
+#
+# Inspect the delivered files with:
+#     openssl pkcs12 -info -in <file>.pfx -passin pass:<password> -noout
+#     openssl pkcs12 -info -in <file>_legacy.pfx -passin pass:<password> -noout -legacy
+#
+#   'Legacy' - the *_legacy file  (SHA-1 MAC, RC2-40 / 3DES)
+#   'Modern' - the plain file     (SHA-256 MAC, AES-256-CBC)
+#   'First'  - whatever the payload lists first; only sensible when a single PFX
+#              is delivered, because payload order is not guaranteed to be stable
+$IIS_PFX_VARIANT = 'Legacy'
+
+# Advanced. Leave '' unless the delivered file names do not follow the _legacy
+# naming above; when set, this regex overrides $IIS_PFX_VARIANT entirely.
+$IIS_PFX_FILE_PATTERN = ''
+
 # Safety net - abort if the new certificate does not carry this common name.
 # Set to '' to disable the check.
 $IIS_EXPECTED_SUBJECT_CN = 'iis-01.digicert-demo.com'
@@ -305,10 +350,63 @@ if ($JSON_OBJECT.args) {
 $CERT_FOLDER = $JSON_OBJECT.certfolder
 Write-LogMessage "Extracted CERT_FOLDER: $CERT_FOLDER"
 
-# Extract the .pfx file name
+# Extract the .pfx file name.
+# When TLM delivers both a modern and a legacy PKCS#12 container there is more than
+# one PFX in the payload, so the selection is made explicit rather than left to the
+# order the files happen to appear in. See $IIS_PFX_VARIANT at the top of the file.
 $PFX_FILE = ""
 if ($JSON_OBJECT.files) {
-    $PFX_FILE = $JSON_OBJECT.files | Where-Object { $_ -match '\.pfx$|\.p12$' } | Select-Object -First 1
+    $pfxCandidates = @($JSON_OBJECT.files | Where-Object { $_ -match '\.pfx$|\.p12$' })
+    Write-LogMessage "PFX candidates in payload ($($pfxCandidates.Count)): $(if ($pfxCandidates.Count) { $pfxCandidates -join ', ' } else { '<none>' })"
+
+    # AWR Parameter 4 overrides the configured variant for a single job.
+    $pfxVariant = $IIS_PFX_VARIANT
+    if (-not [string]::IsNullOrWhiteSpace($ARGUMENT_4)) {
+        if ($ARGUMENT_4 -match '^(LEGACY|MODERN|FIRST)$') {
+            $pfxVariant = $ARGUMENT_4
+            Write-LogMessage "PFX variant overridden by AWR Parameter 4: $pfxVariant"
+        } else {
+            Write-LogMessage "WARNING: AWR Parameter 4 '$ARGUMENT_4' is not LEGACY, MODERN or FIRST - ignored, keeping the configured variant '$pfxVariant'"
+        }
+    }
+
+    # Resolve the variant to a file name pattern. An explicit pattern wins.
+    $pfxPattern = ''
+    $pfxReason  = ''
+    if (-not [string]::IsNullOrWhiteSpace($IIS_PFX_FILE_PATTERN)) {
+        $pfxPattern = $IIS_PFX_FILE_PATTERN
+        $pfxReason  = "the `$IIS_PFX_FILE_PATTERN override '$pfxPattern'"
+    } else {
+        switch ($pfxVariant) {
+            'Legacy' { $pfxPattern = '_legacy\.(pfx|p12)$';      $pfxReason = 'variant Legacy (older PKCS#12 container)' }
+            'Modern' { $pfxPattern = '(?<!_legacy)\.(pfx|p12)$'; $pfxReason = 'variant Modern (AES-256 PKCS#12 container)' }
+            'First'  { $pfxPattern = '';                         $pfxReason = 'variant First (payload order)' }
+            default  {
+                Write-LogMessage "WARNING: `$IIS_PFX_VARIANT '$pfxVariant' is not Legacy, Modern or First - falling back to the first PFX in the payload"
+                $pfxPattern = ''
+                $pfxReason  = 'an unrecognised variant'
+            }
+        }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($pfxPattern) -and $pfxCandidates.Count -gt 0) {
+        $PFX_FILE = $pfxCandidates | Where-Object { $_ -match $pfxPattern } | Select-Object -First 1
+        if ($PFX_FILE) {
+            Write-LogMessage "Selected the PFX for $($pfxReason): $PFX_FILE"
+        } else {
+            # Worth flagging loudly: asking for the legacy container and silently
+            # getting the modern one is the exact mix-up this setting prevents, and
+            # on an older host it then fails looking like a wrong password.
+            Write-LogMessage "WARNING: no delivered PFX matched $($pfxReason) - falling back to the first PFX in the payload"
+        }
+    }
+
+    if ([string]::IsNullOrEmpty($PFX_FILE)) {
+        $PFX_FILE = $pfxCandidates | Select-Object -First 1
+        if ($pfxCandidates.Count -gt 1 -and [string]::IsNullOrWhiteSpace($pfxPattern)) {
+            Write-LogMessage "WARNING: $($pfxCandidates.Count) PFX files were delivered and no variant filter applies - using payload order, which is not guaranteed to be stable between renewals. Set `$IIS_PFX_VARIANT to Legacy or Modern."
+        }
+    }
 }
 Write-LogMessage "Extracted PFX_FILE: $PFX_FILE"
 
@@ -321,13 +419,11 @@ elseif ($JSON_OBJECT.keystore_password) { $PFX_PASSWORD = $JSON_OBJECT.keystore_
 elseif ($JSON_OBJECT.passphrase) { $PFX_PASSWORD = $JSON_OBJECT.passphrase }
 
 if ([string]::IsNullOrEmpty($PFX_PASSWORD)) {
-    Write-LogMessage "WARNING: No PFX password found in JSON. Checking if password is in arguments..."
-    if (-not [string]::IsNullOrEmpty($ARGUMENT_4)) {
-        Write-LogMessage "Checking if Argument 4 could be the password..."
-    }
-    if (-not [string]::IsNullOrEmpty($ARGUMENT_5)) {
-        Write-LogMessage "Checking if Argument 5 could be the password..."
-    }
+    # The AWR arguments are NOT searched for a password: Parameter 4 is the PFX
+    # selection pattern and the rest are unused here, so treating any of them as a
+    # possible password would be wrong as well as a way to leak one into the log.
+    Write-LogMessage "WARNING: No PFX password found in the payload (checked password, pfx_password, keystore_password, passphrase)"
+    Write-LogMessage "         A password-protected PFX cannot be imported without it - the run will fail at the import step."
 } else {
     Write-LogMessage "PFX password extracted from JSON"
     # Length only - never any part of the value itself. Enough to tell an empty or
@@ -411,7 +507,8 @@ if (Test-Path $PFX_FILE_PATH) {
             
             $pfxCert.Dispose()
         } catch {
-            Write-LogMessage "WARNING: Could not access PFX file with provided password: $_"
+            Write-LogMessage "WARNING: Could not open the PFX for inspection: $_"
+            Write-LogMessage "         Either the password is wrong or this host cannot read the PKCS#12 container (see `$IIS_PFX_VARIANT). This block is diagnostic only - the deployment below reports the real outcome."
         }
     } else {
         Write-LogMessage "No password provided, cannot inspect PFX contents"
@@ -490,6 +587,9 @@ Write-LogMessage "=========================================="
 #   AWR Parameter 1 : comma separated site list, or ALL for every https site
 #   AWR Parameter 2 : expected subject CN, or NONE to disable the CN check
 #   AWR Parameter 3 : REMOVEOLD to delete the certificate that was replaced
+#   AWR Parameter 4 : LEGACY, MODERN or FIRST - which delivered PFX to deploy.
+#                     Applied earlier, at PFX selection time - not in this block,
+#                     because $PFX_FILE is resolved before this point.
 # NOTE: arguments are whitespace-stripped during extraction, so site names that
 #       contain spaces (e.g. "Default Web Site") must stay in $IIS_TARGET_SITES.
 if (-not [string]::IsNullOrWhiteSpace($ARGUMENT_1)) {
@@ -731,7 +831,11 @@ function Update-IisCertificateBindings {
     try {
         $pfxCollection.Import($PFX_FILE_PATH, $pfxPasswordOrNull, $keyFlags)
     } catch {
-        Write-LogMessage "ERROR: Unable to read the PFX (wrong password or corrupt file?): $_"
+        # A PKCS#12 container this host cannot decrypt reports itself as a bad
+        # password, so name the other cause here rather than sending whoever reads
+        # this log on a password hunt.
+        Write-LogMessage "ERROR: Unable to read the PFX: $_"
+        Write-LogMessage "       Causes, in order of likelihood: wrong password; a PKCS#12 container this host cannot read (AES-256/PBES2 is unsupported on older Windows and fails looking exactly like a bad password - set `$IIS_PFX_VARIANT = 'Legacy' to use the *_legacy file); corrupt file."
         $script:IIS_ERRORS++
         return
     }


### PR DESCRIPTION
- Added a new parameter to the AWR script to specify which PFX variant to deploy (LEGACY, MODERN, or FIRST). This allows for better control over which PFX file is used during deployment, especially in environments with varying support for PKCS#12 containers.
- Improved error handling and logging when importing PFX files. The script now provides more detailed messages about potential causes of import failures, including unsupported encryption algorithms and incorrect passwords.
- Enhanced diagnostic logging when inspecting PFX files. If the script cannot open the PFX for inspection, it now logs a warning with potential reasons